### PR TITLE
Reorder the <title> attribute to ensure the charset is found early

### DIFF
--- a/girder_style/templates/girder_style/base.html
+++ b/girder_style/templates/girder_style/base.html
@@ -3,10 +3,11 @@
 <html>
 {% block head %}
 <head>
-  <title>{% block head_title %}{% endblock %}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  
+  <title>{% block head_title %}{% endblock %}</title>
 
   <link rel="stylesheet" href="{% static 'girder_style/styles.css' %}">
   <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
`<meta>` elements which declare a character encoding must be located entirely within the first 1024 bytes of the document.